### PR TITLE
Remove duplicated useEffect

### DIFF
--- a/packages/admob/lib/ads/BannerAd.js
+++ b/packages/admob/lib/ads/BannerAd.js
@@ -41,12 +41,6 @@ function BannerAd({ unitId, size, requestOptions, ...props }) {
     }
   }, [size]);
 
-  useEffect(() => {
-    if (!BannerAdSize[size] && !sizeRegex.test(size)) {
-      throw new Error("BannerAd: 'size' expected a valid BannerAdSize or custom size string.");
-    }
-  }, [size]);
-
   const parsedRequestOptions = JSON.stringify(requestOptions);
 
   useEffect(() => {


### PR DESCRIPTION

### Description
useEffect for check Banner AdSize has been used twice. So I removed the redundant one

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues
None

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary
None
<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
